### PR TITLE
Fix autostart openldap issue.

### DIFF
--- a/deployment_scripts/modules/openldap/manifests/master/configure.pp
+++ b/deployment_scripts/modules/openldap/manifests/master/configure.pp
@@ -30,6 +30,13 @@ class openldap::master::configure (
           mode    => '0640',
           content => template("openldap/master-slapd.conf.tmpl.erb"),
     } ->
+    file {'/etc/supervisor/slapd.sh':
+      owner   => 'root',
+      group   => 'root',
+      mode    => '0755',
+      content => template("openldap/slapd-master.sh.tmpl.erb"),
+      notify  => Service['supervisor']
+    } ->
     file {"/etc/supervisor/conf.d/slapd-master.conf":
       path    => "/etc/supervisor/conf.d/slapd-master.conf",
       owner   => 'root',

--- a/deployment_scripts/modules/openldap/manifests/slave/configure.pp
+++ b/deployment_scripts/modules/openldap/manifests/slave/configure.pp
@@ -60,6 +60,13 @@ class openldap::slave::configure (
       }
     }
 
+    file {'/etc/supervisor/slapd.sh':
+      owner   => 'root',
+      group   => 'root',
+      mode    => '0755',
+      content => template("openldap/slapd-slave.sh.tmpl.erb"),
+      notify  => Service['supervisor']
+    } ->
     file {"/etc/supervisor/conf.d/slapd-slave.conf":
       path    => "/etc/supervisor/conf.d/slapd-slave.conf",
       owner   => 'root',

--- a/deployment_scripts/modules/openldap/templates/slapd-master.sh.tmpl.erb
+++ b/deployment_scripts/modules/openldap/templates/slapd-master.sh.tmpl.erb
@@ -1,0 +1,8 @@
+#!/bin/bash
+piddir=/var/run/slapd
+if [ ! -d "$piddir" ]; then
+        mkdir -p "$piddir"
+        [ -z "openldap" ] || chown -R "openldap" "$piddir"
+        [ -z "openldap" ] || chgrp -R "openldap" "$piddir"
+fi
+exec /usr/sbin/slapd -d0 -g openldap -u openldap -f /etc/ldap/slapd.conf -h "ldap:// ldapi:///"

--- a/deployment_scripts/modules/openldap/templates/slapd-slave.sh.tmpl.erb
+++ b/deployment_scripts/modules/openldap/templates/slapd-slave.sh.tmpl.erb
@@ -1,0 +1,8 @@
+#!/bin/bash
+piddir=/var/run/slapd
+if [ ! -d "$piddir" ]; then
+        mkdir -p "$piddir"
+        [ -z "openldap" ] || chown -R "openldap" "$piddir"
+        [ -z "openldap" ] || chgrp -R "openldap" "$piddir"
+fi
+exec /usr/sbin/slapd -d0 -g openldap -u openldap -f /etc/ldap/slapd.conf -h "ldap://127.0.0.1 ldapi:///"

--- a/deployment_scripts/modules/openldap/templates/supervisor-slapd-master.tmpl.erb
+++ b/deployment_scripts/modules/openldap/templates/supervisor-slapd-master.tmpl.erb
@@ -1,5 +1,5 @@
 [program:slapd-master]
-command=/usr/sbin/slapd -d0 -g openldap -u openldap -f /etc/ldap/slapd.conf -h "ldap:// ldapi:///"
+command=/etc/supervisor/slapd.sh
 numprocs=1
 numprocs_start=0
 priority=30

--- a/deployment_scripts/modules/openldap/templates/supervisor-slapd-slave.tmpl.erb
+++ b/deployment_scripts/modules/openldap/templates/supervisor-slapd-slave.tmpl.erb
@@ -1,5 +1,5 @@
 [program:slapd-slave]
-command=/usr/sbin/slapd -d0 -g openldap -u openldap -f /etc/ldap/slapd.conf -h "ldap://127.0.0.1 ldapi:///"
+command=/etc/supervisor/slapd.sh
 numprocs=1
 numprocs_start=0
 priority=30


### PR DESCRIPTION
Openldap cannot be started after reboot node
because of /var/run/slapd directory does not exist